### PR TITLE
Add core Datadog API calls

### DIFF
--- a/datadog.cabal
+++ b/datadog.cabal
@@ -33,6 +33,7 @@ library
                        aeson >=0.8 && <0.10,
                        http-client >=0.4 && <0.5,
                        http-client-tls >=0.2 && <0.3,
+                       http-types >=0.8 && <0.9,
                        lens,
                        bytestring,
                        time,

--- a/datadog.cabal
+++ b/datadog.cabal
@@ -27,7 +27,7 @@ library
                        -- Datadog.Metrics,
                        -- Datadog,
                        -- Datadog.Wai
-  -- other-modules:       
+  other-modules:       Network.Datadog.Internal
   other-extensions:    OverloadedStrings, GeneralizedNewtypeDeriving, TemplateHaskell, FunctionalDependencies, MultiParamTypeClasses, FlexibleInstances
   build-depends:       base >=4.7 && <5,
                        aeson >=0.8 && <0.10,
@@ -47,6 +47,7 @@ library
                        vector >=0.10 && <0.11
   hs-source-dirs:      src
   default-language:    Haskell2010
+  ghc-options:         -Wall
 
 test-suite datadog-api-test
   type:                detailed-0.9

--- a/datadog.cabal
+++ b/datadog.cabal
@@ -31,7 +31,8 @@ library
   other-extensions:    OverloadedStrings, GeneralizedNewtypeDeriving, TemplateHaskell, FunctionalDependencies, MultiParamTypeClasses, FlexibleInstances
   build-depends:       base >=4.7 && <5,
                        aeson >=0.8 && <0.10,
-                       http-conduit >=2.1 && <2.2,
+                       http-client >=0.4 && <0.5,
+                       http-client-tls >=0.2 && <0.3,
                        lens,
                        bytestring,
                        time,

--- a/datadog.cabal
+++ b/datadog.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                datadog
-version:             0.1.0.1
+version:             0.1.1.0
 synopsis:            Datadog client for Haskell. Currently only StatsD supported, other support forthcoming.
 -- description:         
 homepage:            https://github.com/iand675/datadog
@@ -17,7 +17,13 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     Network.Datadog.StatsD
+  exposed-modules:     Network.Datadog,
+                       Network.Datadog.Check,
+                       Network.Datadog.Downtime,
+                       Network.Datadog.Event,
+                       Network.Datadog.Host,
+                       Network.Datadog.Monitor
+                       Network.Datadog.StatsD
                        -- Datadog.Metrics,
                        -- Datadog,
                        -- Datadog.Wai
@@ -25,6 +31,7 @@ library
   other-extensions:    OverloadedStrings, GeneralizedNewtypeDeriving, TemplateHaskell, FunctionalDependencies, MultiParamTypeClasses, FlexibleInstances
   build-depends:       base >=4.7 && <5,
                        aeson >=0.8 && <0.10,
+                       http-conduit >=2.1 && <2.2,
                        lens,
                        bytestring,
                        time,
@@ -35,20 +42,26 @@ library
                        network,
                        monad-control ==1.*,
                        lifted-base,
-                       transformers-base
+                       transformers-base,
+                       unordered-containers >=0.2 && <0.3,
+                       vector >=0.10 && <0.11
   hs-source-dirs:      src
   default-language:    Haskell2010
 
-test-suite datadog-test
-  type:                exitcode-stdio-1.0
-  main-is:             TestAll.hs
-  build-depends:       base,
+test-suite datadog-api-test
+  type:                detailed-0.9
+  test-module:         Test.Network.Datadog
+  other-modules:       Test.Network.Datadog.Check,
+                       Test.Network.Datadog.Downtime,
+                       Test.Network.Datadog.Event,
+                       Test.Network.Datadog.Host,
+                       Test.Network.Datadog.Monitor,
+                       Test.Network.Datadog.StatsD
+  build-depends:       base >=4.8 && <4.9,
+                       Cabal >=1.9.2,
                        datadog,
-                       tasty,
-                       tasty-hunit,
                        network,
-                       text
+                       time >=1.5 && <1.6
   hs-source-dirs:      test
   default-language:    Haskell2010
   ghc-options:         -Wall -O3 -threaded -rtsopts -with-rtsopts=-N
-

--- a/src/Network/Datadog.hs
+++ b/src/Network/Datadog.hs
@@ -17,7 +17,8 @@ import Data.Aeson
 import Data.Aeson.Types (modifyFailure, typeMismatch)
 import qualified Data.Text as T
 
-import Network.HTTP.Conduit
+import Network.HTTP.Client (Manager, newManager)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
 
 import System.Environment (getEnv)
 
@@ -54,7 +55,7 @@ data Environment = Environment { envKeys :: Keys
 -- Datadog documented default API URL.
 createEnvironment :: Keys -> IO Environment
 createEnvironment keys = fmap (Environment keys "https://app.datadoghq.com/api/v1/") managerIO
-  where managerIO = newManager conduitManagerSettings
+  where managerIO = newManager tlsManagerSettings
 
 
 -- | Entity descriptor.

--- a/src/Network/Datadog.hs
+++ b/src/Network/Datadog.hs
@@ -1,0 +1,49 @@
+{-|
+<https://datadoghq.com Datadog> is a monitoring service for IT, Operations and
+Development teams who write and run applications at scale, and want to turn the
+massive amounts of data produced by their apps, tools and services into
+actionable insight.
+-}
+module Network.Datadog
+( Keys(..)
+, loadKeysFromEnv
+, Environment(..)
+, createEnvironment
+) where
+
+
+import Network.HTTP.Conduit
+
+import System.Environment (getEnv)
+
+
+-- | Wraps the keys needed by Datadog to fully access the API.
+data Keys = Keys { apiKey :: String
+                   -- A write-key associated with a user
+                 , appKey :: String
+                   -- A read-key associated with an application
+                 } deriving (Eq)
+
+-- | Load Datadog keys from environment variables.
+--
+-- The keys will be read from the enviornment variables
+-- `DATADOG_API_KEY` and `DATADOG_APP_KEY`. If the keys cannot be read, this
+-- function will throw an 'IOException'.
+loadKeysFromEnv :: IO Keys
+loadKeysFromEnv = do
+  api <- getEnv "DATADOG_API_KEY"
+  app <- getEnv "DATADOG_APP_KEY"
+  return $ Keys api app
+
+
+-- | An Environment contains everything needed to interact with Datadog.
+data Environment = Environment { envKeys :: Keys
+                                 -- ^ Auth keys to permit communication with Datadog
+                               , envManager :: Manager
+                                 -- ^ HTTP manager used to make requests to Datadog
+                               }
+
+-- | Create a new environment using authentication keys
+createEnvironment :: Keys -> IO Environment
+createEnvironment keys = fmap (Environment keys) managerIO
+  where managerIO = newManager conduitManagerSettings

--- a/src/Network/Datadog.hs
+++ b/src/Network/Datadog.hs
@@ -44,13 +44,16 @@ loadKeysFromEnv = do
 -- | An Environment contains everything needed to interact with Datadog.
 data Environment = Environment { envKeys :: Keys
                                  -- ^ Auth keys to permit communication with Datadog
+                               , envAPIUrl :: String
+                                 -- ^ The root URL for the Datadog API
                                , envManager :: Manager
                                  -- ^ HTTP manager used to make requests to Datadog
                                }
 
--- | Create a new environment using authentication keys
+-- | Create a new environment using authentication keys, defaulting to the
+-- Datadog documented default API URL.
 createEnvironment :: Keys -> IO Environment
-createEnvironment keys = fmap (Environment keys) managerIO
+createEnvironment keys = fmap (Environment keys "https://app.datadoghq.com/api/v1/") managerIO
   where managerIO = newManager conduitManagerSettings
 
 

--- a/src/Network/Datadog/Check.hs
+++ b/src/Network/Datadog/Check.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Checks allow users to post check statuses, for use with monitors.
+-}
+module Network.Datadog.Check
+( CheckStatus(..)
+, CheckResult(..)
+, recordCheck
+) where
+
+
+import Control.Monad (mzero, void)
+
+import Data.Aeson
+import Data.Text (Text, dropWhile, intercalate, tail, takeWhile)
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+
+import Network.HTTP.Conduit
+
+import Network.Datadog
+
+
+-- | The status of a service, based on a check that is run against it.
+data CheckStatus = CheckOk
+                   -- ^ Everything is as it should be.
+                 | CheckWarning
+                   -- ^ Something abnormal, but not critical, is amiss.
+                 | CheckCritical
+                   -- ^ Something dangerously critical is amiss.
+                 | CheckUnknown
+                   -- ^ The current status cannot be determined.
+                 deriving (Eq)
+
+instance ToJSON CheckStatus where
+  toJSON CheckOk = Number 0
+  toJSON CheckWarning = Number 1
+  toJSON CheckCritical = Number 2
+  toJSON CheckUnknown = Number 3
+
+instance FromJSON CheckStatus where
+  parseJSON (Number 0) = return CheckOk
+  parseJSON (Number 1) = return CheckWarning
+  parseJSON (Number 2) = return CheckCritical
+  parseJSON (Number 3) = return CheckUnknown
+  parseJSON _ = mzero
+
+
+-- | The result of running a check on some service.
+data CheckResult = CheckResult { crCheck :: Text
+                                 -- ^ Text describing the check
+                               , crHostName :: Text
+                                 -- ^ Name of the host which the check applies to
+                               , crStatus :: CheckStatus
+                                 -- ^ Status result of the check
+                               , crTimestamp :: Maybe UTCTime
+                                 -- ^ Time at which the check occurred (Nothing will wait until the
+                                 -- check is sent to Datadog to compute the time)
+                               , crMessage :: Maybe Text
+                                 -- ^ Information related to why this specific check run supplied
+                                 -- the status it did
+                               , crTags :: [(Text,Text)]
+                                 -- ^ (key,value) tags to associate with this check run
+                               } deriving (Eq)
+
+instance ToJSON CheckResult where
+  toJSON cr = object (["check" .= crCheck cr
+                      ,"host_name" .= crHostName cr
+                      ,"status" .= (\(Number a) -> a) (toJSON (crStatus cr))
+                      ,"tags" .= map (\(a,b) -> intercalate ":" [a,b]) (crTags cr)]
+                      ++ maybe [] (\a -> ["timestamp" .= (floor (utcTimeToPOSIXSeconds a) :: Integer)]) (crTimestamp cr)
+                      ++ maybe [] (\a -> ["message" .= a]) (crMessage cr))
+
+instance FromJSON CheckResult where
+  parseJSON (Object v) = CheckResult <$>
+                         v .: "check" <*>
+                         v .: "host_name" <*>
+                         v .: "status" <*>
+                         v .:? "timestamp" .!= Nothing <*>
+                         v .:? "message" .!= Nothing <*>
+                         (map keyvalue <$> (v .: "tags"))
+    where keyvalue a = (Data.Text.takeWhile (/=':') a, Data.Text.tail (Data.Text.dropWhile (/=':') a))
+  parseJSON _ = mzero
+
+
+-- | Record the result of a check in Datadog.
+recordCheck :: Environment -> CheckResult -> IO ()
+recordCheck (Environment keys manager) checkResult = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/check_run?api_key=" ++ apiKey keys
+  let request = initReq { method = "POST"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode checkResult)
+                        }
+  void $ httpLbs request manager

--- a/src/Network/Datadog/Check.hs
+++ b/src/Network/Datadog/Check.hs
@@ -18,9 +18,8 @@ import Data.Text (Text, dropWhile, intercalate, tail, takeWhile)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
-import Network.HTTP.Conduit
-
 import Network.Datadog
+import Network.Datadog.Internal
 
 
 -- | The status of a service, based on a check that is run against it.
@@ -89,10 +88,6 @@ instance FromJSON CheckResult where
 
 -- | Record the result of a check in Datadog.
 recordCheck :: Environment -> CheckResult -> IO ()
-recordCheck (Environment keys manager) checkResult = do
-  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/check_run?api_key=" ++ apiKey keys
-  let request = initReq { method = "POST"
-                        , requestHeaders = [("Content-type","application/json")]
-                        , requestBody = RequestBodyLBS (encode checkResult)
-                        }
-  void $ httpLbs request manager
+recordCheck env checkResult =
+  let path = "check_run"
+  in void $ datadogHttp env path [] "POST" $ Just $ encode checkResult

--- a/src/Network/Datadog/Check.hs
+++ b/src/Network/Datadog/Check.hs
@@ -18,6 +18,8 @@ import Data.Text (Text)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
+import Network.HTTP.Types
+
 import Network.Datadog
 import Network.Datadog.Internal
 
@@ -91,4 +93,4 @@ instance FromJSON CheckResult where
 recordCheck :: Environment -> CheckResult -> IO ()
 recordCheck env checkResult =
   let path = "check_run"
-  in void $ datadogHttp env path [] "POST" $ Just $ encode checkResult
+  in void $ datadogHttp env path [] POST $ Just $ encode checkResult

--- a/src/Network/Datadog/Check.hs
+++ b/src/Network/Datadog/Check.hs
@@ -66,12 +66,14 @@ data CheckResult = CheckResult { crCheck :: Text
                                } deriving (Eq)
 
 instance ToJSON CheckResult where
-  toJSON cr = object (["check" .= crCheck cr
-                      ,"host_name" .= crHostName cr
-                      ,"status" .= crStatus cr
-                      ,"tags" .= crTags cr]
-                      ++ maybe [] (\a -> ["timestamp" .= (floor (utcTimeToPOSIXSeconds a) :: Integer)]) (crTimestamp cr)
-                      ++ maybe [] (\a -> ["message" .= a]) (crMessage cr))
+  toJSON cr = object $
+              prependMaybe (\a -> "timestamp" .= (floor (utcTimeToPOSIXSeconds a) :: Integer)) (crTimestamp cr) $
+              prependMaybe (\a -> "message" .= a) (crMessage cr)
+              ["check" .= crCheck cr
+              ,"host_name" .= crHostName cr
+              ,"status" .= crStatus cr
+              ,"tags" .= crTags cr
+              ]
 
 instance FromJSON CheckResult where
   parseJSON (Object v) = modifyFailure ("CheckResult: " ++) $

--- a/src/Network/Datadog/Downtime.hs
+++ b/src/Network/Datadog/Downtime.hs
@@ -22,7 +22,7 @@ import Control.Monad (void)
 
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure, typeMismatch)
-import qualified Data.HashMap.Strict as Data.HashMap (union)
+import qualified Data.HashMap.Strict as Data.HashMap (insert)
 import Data.Text (Text)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
@@ -82,9 +82,8 @@ data Downtime = Downtime { dId :: DowntimeId
                          } deriving (Eq)
 
 instance ToJSON Downtime where
-  toJSON downtime = Object $ Data.HashMap.union basemap newmap
+  toJSON downtime = Object $ Data.HashMap.insert "id" (toJSON (dId downtime)) basemap
     where (Object basemap) = toJSON (dSpec downtime)
-          (Object newmap) = object ["id" .= dId downtime]
 
 instance FromJSON Downtime where
   parseJSON (Object v) = modifyFailure ("Downtime: " ++) $

--- a/src/Network/Datadog/Downtime.hs
+++ b/src/Network/Datadog/Downtime.hs
@@ -46,11 +46,10 @@ data DowntimeSpec = DowntimeSpec { dsScope :: Tag
                                  } deriving (Eq)
 
 instance ToJSON DowntimeSpec where
-  toJSON ds = object (["scope" .= dsScope ds]
-                      ++ maybe [] (\a -> ["start" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)]) (dsStart ds)
-                      ++ maybe [] (\a -> ["end" .= (floor (utcTimeToPOSIXSeconds a) :: Integer)]) (dsEnd ds)
-                      ++ maybe [] (\a -> ["message" .= a]) (dsMessage ds)
-                     )
+  toJSON ds = object $
+              prependMaybe (\a -> "start" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)) (dsStart ds) $
+              prependMaybe (\a -> "end" .= (floor (utcTimeToPOSIXSeconds a) :: Integer)) (dsEnd ds)
+              ["scope" .= dsScope ds]
 
 instance FromJSON DowntimeSpec where
   parseJSON (Object v) = modifyFailure ("DowntimeSpec: " ++) $

--- a/src/Network/Datadog/Downtime.hs
+++ b/src/Network/Datadog/Downtime.hs
@@ -33,8 +33,10 @@ import Network.Datadog.Internal
 
 
 -- | A description of when downtime should occur.
-data DowntimeSpec = DowntimeSpec { dsScope :: Text
-                                   -- ^ The scope/tag(s) to apply downtime to
+data DowntimeSpec = DowntimeSpec { dsScope :: Tag
+                                   -- ^ The scope to apply downtime to (if applying downtime to a
+                                   -- host, use a tag of the form "host:hostname", NOT just
+                                   -- "hostname")
                                  , dsStart :: Maybe UTCTime
                                    -- ^ When to start the downtime (or immediately)
                                  , dsEnd :: Maybe UTCTime
@@ -62,7 +64,7 @@ instance FromJSON DowntimeSpec where
 
 -- | Creates the most basic possible downtime specification, which just
 -- contains the scope to which the downtime applies.
-minimalDowntimeSpec :: Text -> DowntimeSpec
+minimalDowntimeSpec :: Tag -> DowntimeSpec
 minimalDowntimeSpec scope = DowntimeSpec { dsScope = scope
                                          , dsStart = Nothing
                                          , dsEnd = Nothing

--- a/src/Network/Datadog/Downtime.hs
+++ b/src/Network/Datadog/Downtime.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Downtime prevents all alerting related to specific Datadog scopes.
+-}
+module Network.Datadog.Downtime
+( DowntimeSpec(..)
+, Downtime
+, dId
+, dSpec
+, DowntimeId
+, minimalDowntimeSpec
+, scheduleDowntime
+, updateDowntime
+, cancelDowntime
+, loadDowntime
+, loadDowntimes
+) where
+
+
+import Control.Exception
+import Control.Monad (mzero, void)
+
+import Data.Aeson
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.HashMap.Strict as Data.HashMap (union)
+import Data.Text (Text)
+import qualified Data.Text.Lazy (unpack)
+import Data.Text.Lazy.Encoding (decodeUtf8)
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+import qualified Data.Vector (head)
+
+import Network.HTTP.Conduit
+
+import Network.Datadog
+
+
+-- | A description of when downtime should occur.
+data DowntimeSpec = DowntimeSpec { dsScope :: Text
+                                   -- ^ The scope/tag(s) to apply downtime to
+                                 , dsStart :: Maybe UTCTime
+                                   -- ^ When to start the downtime (or immediately)
+                                 , dsEnd :: Maybe UTCTime
+                                   -- ^ When to stop the downtime (or indefinitely)
+                                 , dsMessage :: Maybe Text
+                                   -- ^ A message to include with notifications for this downtime
+                                 } deriving (Eq)
+
+instance ToJSON DowntimeSpec where
+  toJSON ds = object (["scope" .= dsScope ds]
+                      ++ maybe [] (\a -> ["start" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)]) (dsStart ds)
+                      ++ maybe [] (\a -> ["end" .= (floor (utcTimeToPOSIXSeconds a) :: Integer)]) (dsEnd ds)
+                      ++ maybe [] (\a -> ["message" .= a]) (dsMessage ds)
+                     )
+
+instance FromJSON DowntimeSpec where
+  parseJSON (Object v) = DowntimeSpec <$>
+                         (withArray "Text" (parseJSON . Data.Vector.head) =<< v .: "scope") <*>
+                         (maybe (return Nothing) (withScientific "Integer" (\t -> return (Just (posixSecondsToUTCTime (fromIntegral (floor t :: Integer)))))) =<< (v .:? "start")) <*>
+                         (maybe (return Nothing) (withScientific "Integer" (\t -> return (Just (posixSecondsToUTCTime (fromIntegral (floor t :: Integer)))))) =<< (v .:? "end")) <*>
+                         v .:? "message" .!= Nothing
+  parseJSON _ = mzero
+
+
+-- | Creates the most basic possible downtime specification, which just
+-- contains the scope to which the downtime applies.
+minimalDowntimeSpec :: Text -> DowntimeSpec
+minimalDowntimeSpec scope = DowntimeSpec { dsScope = scope
+                                         , dsStart = Nothing
+                                         , dsEnd = Nothing
+                                         , dsMessage = Nothing
+                                         }
+
+
+-- | Datadog's internal reference to a specific donwtime instance.
+type DowntimeId = Int
+
+-- | A scheduled donwtime stored in Datadog.
+data Downtime = Downtime { dId :: DowntimeId
+                           -- ^ Datadog's unique reference to the scheduled downtime
+                         , dSpec :: DowntimeSpec
+                           -- ^ Context on the downtime schedule
+                         } deriving (Eq)
+
+instance ToJSON Downtime where
+  toJSON downtime = Object $ Data.HashMap.union basemap newmap
+    where (Object basemap) = toJSON (dSpec downtime)
+          (Object newmap) = object ["id" .= dId downtime]
+
+instance FromJSON Downtime where
+  parseJSON (Object v) = Downtime <$> v .: "id" <*> parseJSON (Object v)
+  parseJSON _ = mzero
+
+
+downtimeDecode :: ByteString -> IO Downtime
+downtimeDecode body = either (throwIO . AssertionFailed . failstring) return
+                   $ eitherDecode body
+  where failstring e = "Datadog Library could not decode a Downtime - " ++ e
+                       ++ " - " ++ Data.Text.Lazy.unpack (decodeUtf8 body)
+
+downtimesDecode :: ByteString -> IO [Downtime]
+downtimesDecode body = either (throwIO . AssertionFailed . failstring) return
+                   $ eitherDecode body
+  where failstring e = "Datadog Library could not decode Downtimes - " ++ e
+                       ++ " - " ++ Data.Text.Lazy.unpack (decodeUtf8 body)
+
+
+-- | Schedule a new downtime in Datadog.
+scheduleDowntime :: Environment -> DowntimeSpec -> IO Downtime
+scheduleDowntime (Environment keys manager) downtimeSpec = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/downtime?api_key=" ++ apiKey keys
+             ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "POST"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode downtimeSpec)
+                        }
+  resp <- httpLbs request manager
+  downtimeDecode $ responseBody resp
+
+
+-- | Update the specification of a downtime in Datadog.
+updateDowntime :: Environment -> DowntimeId -> DowntimeSpec -> IO Downtime
+updateDowntime (Environment keys manager) did dspec = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/downtime/" ++ show did
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "PUT"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode dspec)
+                        }
+  resp <- httpLbs request manager
+  maybe (throwIO (AssertionFailed "Datadog Library could not decode a Downtime (updateDowntime)")) return
+    $ decode $ responseBody resp
+
+
+-- | Cancel scheduled downtime in Datadog.
+cancelDowntime :: Environment -> DowntimeId -> IO ()
+cancelDowntime (Environment keys manager) downtimeId = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/downtime/" ++ show downtimeId
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "DELETE" }
+  void $ httpLbs request manager
+
+
+-- | Load a scheduled downtime from Datadog by its ID.
+loadDowntime :: Environment -> DowntimeId -> IO Downtime
+loadDowntime (Environment keys manager) downtimeId = do
+  request <- parseUrl $ "https://app.datadoghq.com/api/v1/downtime/" ++ show downtimeId
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  resp <- httpLbs request manager
+  downtimeDecode $ responseBody resp
+
+
+-- | Load all scheduled downtimes, optionally filtering for only downtimes that
+-- are currently active.
+loadDowntimes :: Environment -> Bool -> IO [Downtime]
+loadDowntimes (Environment keys manager) active = do
+  request <- parseUrl $ "https://app.datadoghq.com/api/v1/downtime?api_key=" ++ apiKey keys
+             ++ "&application_key=" ++ appKey keys
+             ++ if active then "&current_only=true" else []
+  resp <- httpLbs request manager
+  downtimesDecode $ responseBody resp

--- a/src/Network/Datadog/Downtime.hs
+++ b/src/Network/Datadog/Downtime.hs
@@ -26,7 +26,7 @@ import qualified Data.HashMap.Strict as Data.HashMap (union)
 import Data.Text (Text)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import qualified Data.Vector (head)
+import Data.Vector ((!?))
 
 import Network.Datadog
 import Network.Datadog.Internal
@@ -54,7 +54,7 @@ instance ToJSON DowntimeSpec where
 instance FromJSON DowntimeSpec where
   parseJSON (Object v) = modifyFailure ("DowntimeSpec: " ++) $
                          DowntimeSpec <$>
-                         (withArray "Text" (parseJSON . Data.Vector.head) =<< v .: "scope") <*>
+                         (withArray "Text" (\t -> maybe (fail "\"scope\" Array is too short") parseJSON (t !? 0)) =<< v .: "scope") <*>
                          (maybe (return Nothing) (withScientific "Integer" (\t -> return (Just (posixSecondsToUTCTime (fromIntegral (floor t :: Integer)))))) =<< (v .:? "start")) <*>
                          (maybe (return Nothing) (withScientific "Integer" (\t -> return (Just (posixSecondsToUTCTime (fromIntegral (floor t :: Integer)))))) =<< (v .:? "end")) <*>
                          v .:? "message" .!= Nothing

--- a/src/Network/Datadog/Downtime.hs
+++ b/src/Network/Datadog/Downtime.hs
@@ -28,6 +28,8 @@ import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Vector ((!?))
 
+import Network.HTTP.Types
+
 import Network.Datadog
 import Network.Datadog.Internal
 
@@ -95,7 +97,7 @@ instance FromJSON Downtime where
 scheduleDowntime :: Environment -> DowntimeSpec -> IO Downtime
 scheduleDowntime env downtimeSpec =
   let path = "downtime"
-  in datadogHttp env path [] "POST" (Just $ encode downtimeSpec) >>=
+  in datadogHttp env path [] POST (Just $ encode downtimeSpec) >>=
      decodeDatadog "scheduleDowntime"
 
 
@@ -103,7 +105,7 @@ scheduleDowntime env downtimeSpec =
 updateDowntime :: Environment -> DowntimeId -> DowntimeSpec -> IO Downtime
 updateDowntime env did dspec =
   let path = "downtime/" ++ show did
-  in datadogHttp env path [] "PUT" (Just $ encode dspec) >>=
+  in datadogHttp env path [] PUT (Just $ encode dspec) >>=
      decodeDatadog "updateDowntime"
 
 
@@ -111,14 +113,14 @@ updateDowntime env did dspec =
 cancelDowntime :: Environment -> DowntimeId -> IO ()
 cancelDowntime env downtimeId =
   let path = "downtime/" ++ show downtimeId
-  in void $ datadogHttp env path [] "DELETE" Nothing
+  in void $ datadogHttp env path [] DELETE Nothing
 
 
 -- | Load a scheduled downtime from Datadog by its ID.
 loadDowntime :: Environment -> DowntimeId -> IO Downtime
 loadDowntime env downtimeId =
   let path = "downtime/" ++ show downtimeId
-  in datadogHttp env path [] "GET" Nothing >>=
+  in datadogHttp env path [] GET Nothing >>=
      decodeDatadog "loadDowntime"
 
 
@@ -128,5 +130,5 @@ loadDowntimes :: Environment -> Bool -> IO [Downtime]
 loadDowntimes env active =
   let path = "downtime"
       query = [("current_only", "true") | active]
-  in datadogHttp env path query "GET" Nothing >>=
+  in datadogHttp env path query GET Nothing >>=
      decodeDatadog "loadDowntimes"

--- a/src/Network/Datadog/Event.hs
+++ b/src/Network/Datadog/Event.hs
@@ -1,0 +1,288 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Events in Datadog represent notable occurrences.
+-}
+module Network.Datadog.Event
+( EventPriority(..)
+, AlertType(..)
+, SourceType(..)
+, EventSpec(..)
+, Event
+, eId
+, eDetails
+, EventId
+, minimalEventSpec
+, createEvent
+, loadEvent
+, loadEvents
+) where
+
+
+import Control.Exception
+import Control.Monad (mzero)
+
+import Data.Aeson hiding (Error, Success)
+-- import qualified Data.Aeson (Result(Success))
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.HashMap.Strict as Data.HashMap
+import Data.List (intercalate)
+import Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import Data.Text (Text, pack, unpack)
+import qualified Data.Text.Lazy (unpack)
+import Data.Text.Lazy.Encoding (decodeUtf8)
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+import Data.Vector (toList)
+
+import Network.HTTP.Conduit
+
+import Network.Datadog
+
+
+-- | A set of priorities used to denote the importance of an event.
+data EventPriority = NormalPriority
+                   | LowPriority
+                   deriving (Eq)
+
+instance Show EventPriority where
+  show NormalPriority = "normal"
+  show LowPriority = "low"
+
+instance ToJSON EventPriority where
+  toJSON NormalPriority = Data.Aeson.String "normal"
+  toJSON LowPriority = Data.Aeson.String "low"
+
+instance FromJSON EventPriority where
+  parseJSON (Data.Aeson.String "normal") = return NormalPriority
+  parseJSON (Data.Aeson.String "low") = return LowPriority
+  parseJSON _ = mzero
+
+
+-- | The failure levels for an alert.
+data AlertType = Error
+               | Warning
+               | Info
+               | Success
+               deriving (Eq)
+
+instance Show AlertType where
+  show Error = "error"
+  show Warning = "warning"
+  show Info = "info"
+  show Success = "success"
+
+instance ToJSON AlertType where
+  toJSON Error = Data.Aeson.String "error"
+  toJSON Warning = Data.Aeson.String "warning"
+  toJSON Info = Data.Aeson.String "info"
+  toJSON Success = Data.Aeson.String "success"
+
+instance FromJSON AlertType where
+  parseJSON (Data.Aeson.String "error") = return Error
+  parseJSON (Data.Aeson.String "warning") = return Warning
+  parseJSON (Data.Aeson.String "info") = return Info
+  parseJSON (Data.Aeson.String "success") = return Success
+  parseJSON _ = mzero
+
+
+-- | A source from which an event may originate, recognized by Datadog.
+data SourceType = Nagios
+                | Hudson
+                | Jenkins
+                | User
+                | MyApps
+                | Feed
+                | Chef
+                | Puppet
+                | Git
+                | BitBucket
+                | Fabric
+                | Capistrano
+                deriving (Eq)
+
+instance Show SourceType where
+  show Nagios = "nagios"
+  show Hudson = "hudson"
+  show Jenkins = "jenkins"
+  show User = "user"
+  show MyApps = "my apps"
+  show Feed = "feed"
+  show Chef = "chef"
+  show Puppet = "puppet"
+  show Git = "git"
+  show BitBucket = "bitbucket"
+  show Fabric = "fabric"
+  show Capistrano = "capistrano"
+
+instance ToJSON SourceType where
+  toJSON Nagios = Data.Aeson.String "nagios"
+  toJSON Hudson = Data.Aeson.String "hudson"
+  toJSON Jenkins = Data.Aeson.String "jenkins"
+  toJSON User = Data.Aeson.String "user"
+  toJSON MyApps = Data.Aeson.String "my apps"
+  toJSON Feed = Data.Aeson.String "feed"
+  toJSON Chef = Data.Aeson.String "chef"
+  toJSON Puppet = Data.Aeson.String "puppet"
+  toJSON Git = Data.Aeson.String "git"
+  toJSON BitBucket = Data.Aeson.String "bitbucket"
+  toJSON Fabric = Data.Aeson.String "fabric"
+  toJSON Capistrano = Data.Aeson.String "capistrano"
+
+instance FromJSON SourceType where
+  parseJSON (Data.Aeson.String "nagios") = return Nagios
+  parseJSON (Data.Aeson.String "hudson") = return Hudson
+  parseJSON (Data.Aeson.String "jenkins") = return Jenkins
+  parseJSON (Data.Aeson.String "user") = return User
+  parseJSON (Data.Aeson.String "my apps") = return MyApps
+  parseJSON (Data.Aeson.String "feed") = return Feed
+  parseJSON (Data.Aeson.String "chef") = return Chef
+  parseJSON (Data.Aeson.String "puppet") = return Puppet
+  parseJSON (Data.Aeson.String "git") = return Git
+  parseJSON (Data.Aeson.String "bitbucket") = return BitBucket
+  parseJSON (Data.Aeson.String "fabric") = return Fabric
+  parseJSON (Data.Aeson.String "capistrano") = return Capistrano
+  parseJSON _ = mzero
+
+
+-- | Details that describe an event.
+data EventSpec = EventSpec { edTitle :: Text
+                           , edText :: Text
+                             -- ^ The description/body of the event
+                           , edDateHappened :: UTCTime
+                             -- ^ The time at which the event occurred
+                           , edPriority :: EventPriority
+                           , edHost :: Maybe Text
+                             -- ^ The hostname associated with the event
+                           , edTags :: HashSet Text
+                           , edAlertType :: AlertType
+                           , edSourceType :: Maybe SourceType
+                             -- ^ The trigger of the event (if identifiable)
+                           } deriving (Eq, Show)
+
+instance ToJSON EventSpec where
+  toJSON ed = object (["title" .= edTitle ed
+                      ,"text" .= edText ed
+                      ,"date_happened" .= (floor (utcTimeToPOSIXSeconds (edDateHappened ed)) :: Integer)
+                      ,"priority" .= pack (show (edPriority ed))
+                      ,"alert_type" .= pack (show (edAlertType ed))
+                      ,"tags" .= HashSet.toList (edTags ed)]
+                      ++ maybe [] (\a -> ["host" .= a]) (edHost ed)
+                      ++ maybe [] (\a -> ["source_type_name" .= pack (show a)]) (edSourceType ed)
+                     )
+
+instance FromJSON EventSpec where
+  parseJSON (Object v) = EventSpec <$>
+                         v .: "title" <*>
+                         v .: "text" <*>
+                         (withScientific "Integer" (\t -> return (posixSecondsToUTCTime (fromIntegral (floor t :: Integer)))) =<< v .: "date_happened") <*>
+                         v .: "priority" <*>
+                         v .:? "host" .!= Nothing <*>
+                         (withArray "List" (fmap HashSet.fromList . mapM (withText "Text" return) . toList) =<< v .: "tags") <*>
+                         v .:? "alert_type" .!= Info <*>
+                         v .:? "source_type" .!= Nothing
+  parseJSON _ = mzero
+
+
+-- | Creates the most basic description required for an event, containing the
+-- event title, descriptive text, time of occurrence, and priority of the
+-- event. This event will be of type Info.
+minimalEventSpec :: Text -> Text -> UTCTime -> EventPriority -> EventSpec
+minimalEventSpec title text time eventPriority = EventSpec { edTitle = title
+                                                           , edText = text
+                                                           , edDateHappened = time
+                                                           , edPriority = eventPriority
+                                                           , edHost = Nothing
+                                                           , edTags = HashSet.empty
+                                                           , edAlertType = Info
+                                                           , edSourceType = Nothing
+                                                           }
+
+
+-- | Datadog's internal reference to a specific event.
+type EventId = Int
+
+-- | An event stored within Datadog. An event represents some sort of
+-- occurrence that was recorded in Datadog.
+data Event = Event { eId :: EventId
+                     -- ^ Datadog's unique reference to the event
+                   , eDetails :: EventSpec
+                     -- ^ Context on what happened during this event
+                   } deriving (Eq, Show)
+
+instance ToJSON Event where
+  toJSON event = Object $ Data.HashMap.union basemap newmap
+    where (Object basemap) = toJSON (eDetails event)
+          (Object newmap) = object ["id" .= eId event]
+
+instance FromJSON Event where
+  parseJSON (Object v) = Event <$> v .: "id" <*> parseJSON (Object v)
+  parseJSON _ = mzero
+
+
+data WrappedEvent = WrappedEvent { wrappedEvent :: Event }
+
+instance FromJSON WrappedEvent where
+  parseJSON (Object v) = WrappedEvent <$> v .: "event"
+  parseJSON _ = mzero
+
+data WrappedEvents = WrappedEvents { wrappedEvents :: [Event] }
+
+instance FromJSON WrappedEvents where
+  parseJSON (Object v) = WrappedEvents <$> v .: "events"
+  parseJSON _ = mzero
+
+
+eventDecode :: ByteString -> IO Event
+eventDecode body = either (throwIO . AssertionFailed . failstring) (return . wrappedEvent)
+                   $ eitherDecode body
+  where failstring e = "Datadog Library could not decode an Event - " ++ e
+                       ++ " - " ++ Data.Text.Lazy.unpack (decodeUtf8 body)
+
+eventsDecode :: ByteString -> IO [Event]
+eventsDecode body = either (throwIO . AssertionFailed . failstring) (return . wrappedEvents)
+                   $ eitherDecode body
+  where failstring e = "Datadog Library could not decode Events - " ++ e
+                       ++ " - " ++ Data.Text.Lazy.unpack (decodeUtf8 body)
+
+
+-- | Store a new event in Datadog.
+createEvent :: Environment -> EventSpec -> IO Event
+createEvent (Environment keys manager) eventDetails = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/events?api_key=" ++ apiKey keys
+  let request = initReq { method = "POST"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode eventDetails)
+                        }
+  resp <- httpLbs request manager
+  eventDecode $ responseBody resp
+
+
+-- | Load an event from Datadog by its ID.
+loadEvent :: Environment -> EventId -> IO Event
+loadEvent (Environment keys manager) eventId = do
+  request <- parseUrl $ "https://app.datadoghq.com/api/v1/events/" ++ show eventId
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  resp <- httpLbs request manager
+  eventDecode $ responseBody resp
+
+
+-- | Query Datadog for events within a specific time range.
+loadEvents :: Environment
+           -> (UTCTime,UTCTime)
+           -- ^ The range within which to query for events
+           -> Maybe EventPriority
+           -- ^ Optionally filter results by a specific priority level
+           -> [Text]
+           -- ^ A list of tags to filter by
+           -> IO [Event]
+loadEvents (Environment keys manager) (start,end) priority tags = do
+  request <- parseUrl $ "https://app.datadoghq.com/api/v1/events?api_key=" ++ apiKey keys
+             ++ "&application_key=" ++ appKey keys
+             ++ "&start=" ++ show (floor (utcTimeToPOSIXSeconds start) :: Integer)
+             ++ "&end=" ++ show (floor (utcTimeToPOSIXSeconds end) :: Integer)
+             ++ maybe "" (\a -> "&priority=" ++ show a) priority
+             ++ if null tags then "" else "&tags=" ++ intercalate "," (map unpack tags)
+  resp <- httpLbs request manager
+  eventsDecode $ responseBody resp

--- a/src/Network/Datadog/Event.hs
+++ b/src/Network/Datadog/Event.hs
@@ -24,7 +24,7 @@ import Control.Monad (liftM)
 import Data.Aeson hiding (Error, Success)
 import Data.Aeson.Types (modifyFailure, typeMismatch)
 -- import qualified Data.Aeson (Result(Success))
-import qualified Data.HashMap.Strict as Data.HashMap
+import qualified Data.HashMap.Strict as Data.HashMap (insert)
 import Data.List (intercalate)
 import Data.Text (Text, pack, unpack)
 import Data.Time.Clock
@@ -210,9 +210,8 @@ data Event = Event { eId :: EventId
                    } deriving (Eq, Show)
 
 instance ToJSON Event where
-  toJSON event = Object $ Data.HashMap.union basemap newmap
+  toJSON event = Object $ Data.HashMap.insert "id" (toJSON (eId event)) basemap
     where (Object basemap) = toJSON (eDetails event)
-          (Object newmap) = object ["id" .= eId event]
 
 instance FromJSON Event where
   parseJSON (Object v) = modifyFailure ("Event: " ++) $

--- a/src/Network/Datadog/Event.hs
+++ b/src/Network/Datadog/Event.hs
@@ -30,6 +30,8 @@ import Data.Text (Text, pack, unpack)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
+import Network.HTTP.Types
+
 import Network.Datadog
 import Network.Datadog.Internal
 
@@ -239,7 +241,7 @@ createEvent :: Environment -> EventSpec -> IO Event
 createEvent env eventDetails =
   let path = "events"
   in liftM wrappedEvent $
-     datadogHttp env path [] "POST" (Just $ encode eventDetails) >>=
+     datadogHttp env path [] POST (Just $ encode eventDetails) >>=
      decodeDatadog "createEvent"
 
 
@@ -248,7 +250,7 @@ loadEvent :: Environment -> EventId -> IO Event
 loadEvent env eventId =
   let path = "events/" ++ show eventId
   in liftM wrappedEvent $
-     datadogHttp env path [] "GET" Nothing >>=
+     datadogHttp env path [] GET Nothing >>=
      decodeDatadog "loadEvent"
 
 -- | Query Datadog for events within a specific time range.
@@ -268,5 +270,5 @@ loadEvents env (start,end) priority tags =
               ,("end", show (floor (utcTimeToPOSIXSeconds end) :: Integer))
               ]
   in liftM wrappedEvents $
-     datadogHttp env path query "GET" Nothing >>=
+     datadogHttp env path query GET Nothing >>=
      decodeDatadog "loadEvent"

--- a/src/Network/Datadog/Host.hs
+++ b/src/Network/Datadog/Host.hs
@@ -16,36 +16,25 @@ import Data.Text (Text, unpack)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
-import Network.HTTP.Conduit
-
 import Network.Datadog
+import Network.Datadog.Internal
 
 
 muteHost :: Environment -> Text -> Maybe UTCTime -> Bool -> IO ()
 -- ^ Do not allow alerts to trigger on a specific host
-muteHost (Environment keys manager) hostname mtime override = do
-  let body = object (["hostname" .= hostname]
+muteHost env hostname mtime override =
+  let path = "host/" ++ unpack hostname ++ "/mute"
+      query = [("override", "true") | override]
+      body = object (["hostname" .= hostname]
                      ++ maybe [] (\a -> ["end" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)]) mtime
                      ++ ["override" .= True | override]
                     )
-  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/host/" ++ unpack hostname
-             ++ "/mute?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
-             ++ if override then "&override=true" else ""
-  let request = initReq { method = "POST"
-                        , requestHeaders = [("Content-type","application/json")]
-                        , requestBody = RequestBodyLBS (encode body)
-                        }
-  void $ httpLbs request manager
+  in void $ datadogHttp env path query "POST" $ Just $ encode body
 
 
 unmuteHost :: Environment -> Text -> IO ()
 -- ^ Allow alerts to trigger on a specific host
-unmuteHost (Environment keys manager) hostname = do
-  let body = object ["hostname" .= hostname]
-  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/host/" ++ unpack hostname
-             ++ "/unmute?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
-  let request = initReq { method = "POST"
-                        , requestHeaders = [("Content-type","application/json")]
-                        , requestBody = RequestBodyLBS (encode body)
-                        }
-  void $ httpLbs request manager
+unmuteHost env hostname =
+  let path = "host/" ++ unpack hostname ++ "/unmute"
+      body = object ["hostname" .= hostname]
+  in void $ datadogHttp env path [] "POST" $ Just $ encode body

--- a/src/Network/Datadog/Host.hs
+++ b/src/Network/Datadog/Host.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Controls host muting in Datadog.
+-}
+module Network.Datadog.Host
+( muteHost
+, unmuteHost
+) where
+
+
+import Control.Monad (void)
+
+import Data.Aeson
+import Data.Text (Text, unpack)
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+
+import Network.HTTP.Conduit
+
+import Network.Datadog
+
+
+muteHost :: Environment -> Text -> Maybe UTCTime -> Bool -> IO ()
+-- ^ Do not allow alerts to trigger on a specific host
+muteHost (Environment keys manager) hostname mtime override = do
+  let body = object (["hostname" .= hostname]
+                     ++ maybe [] (\a -> ["end" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)]) mtime
+                     ++ ["override" .= True | override]
+                    )
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/host/" ++ unpack hostname
+             ++ "/mute?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+             ++ if override then "&override=true" else ""
+  let request = initReq { method = "POST"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode body)
+                        }
+  void $ httpLbs request manager
+
+
+unmuteHost :: Environment -> Text -> IO ()
+-- ^ Allow alerts to trigger on a specific host
+unmuteHost (Environment keys manager) hostname = do
+  let body = object ["hostname" .= hostname]
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/host/" ++ unpack hostname
+             ++ "/unmute?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "POST"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode body)
+                        }
+  void $ httpLbs request manager

--- a/src/Network/Datadog/Host.hs
+++ b/src/Network/Datadog/Host.hs
@@ -25,10 +25,10 @@ muteHost :: Environment -> Text -> Maybe UTCTime -> Bool -> IO ()
 muteHost env hostname mtime override =
   let path = "host/" ++ unpack hostname ++ "/mute"
       query = [("override", "true") | override]
-      body = object (["hostname" .= hostname]
-                     ++ maybe [] (\a -> ["end" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)]) mtime
-                     ++ ["override" .= True | override]
-                    )
+      body = object $
+             prependMaybe (\a -> "end" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)) mtime $
+             prependBool override ("override" .= True)
+             ["hostname" .= hostname]
   in void $ datadogHttp env path query "POST" $ Just $ encode body
 
 

--- a/src/Network/Datadog/Host.hs
+++ b/src/Network/Datadog/Host.hs
@@ -16,6 +16,8 @@ import Data.Text (Text, unpack)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
+import Network.HTTP.Types
+
 import Network.Datadog
 import Network.Datadog.Internal
 
@@ -29,7 +31,7 @@ muteHost env hostname mtime override =
              prependMaybe (\a -> "end" .= (ceiling (utcTimeToPOSIXSeconds a) :: Integer)) mtime $
              prependBool override ("override" .= True)
              ["hostname" .= hostname]
-  in void $ datadogHttp env path query "POST" $ Just $ encode body
+  in void $ datadogHttp env path query POST $ Just $ encode body
 
 
 unmuteHost :: Environment -> Text -> IO ()
@@ -37,4 +39,4 @@ unmuteHost :: Environment -> Text -> IO ()
 unmuteHost env hostname =
   let path = "host/" ++ unpack hostname ++ "/unmute"
       body = object ["hostname" .= hostname]
-  in void $ datadogHttp env path [] "POST" $ Just $ encode body
+  in void $ datadogHttp env path [] POST $ Just $ encode body

--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.Datadog.Internal
+( decodeDatadog
+) where
+
+
+import Control.Exception
+
+import Data.Aeson
+import Data.ByteString.Lazy (ByteString)
+import Data.Text.Lazy (unpack)
+import Data.Text.Lazy.Encoding (decodeUtf8)
+
+
+decodeDatadog :: FromJSON a => String -> ByteString -> IO a
+decodeDatadog funcname body = either (throwIO . AssertionFailed . failstring) return $
+                              eitherDecode body
+  where failstring e = "Datadog Library decoding failure in \"" ++ funcname ++
+                       "\": " ++ e ++ ": " ++ unpack (decodeUtf8 body)

--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -23,8 +23,8 @@ import Network.Datadog
 
 
 datadogHttp :: Environment-> String -> [(String, String)] -> BS.ByteString -> Maybe LBS.ByteString -> IO LBS.ByteString
-datadogHttp (Environment keys manager) endpoint query httpMethod content = do
-  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/" ++ endpoint
+datadogHttp (Environment keys baseUrl manager) endpoint query httpMethod content = do
+  initReq <- parseUrl $ baseUrl ++ endpoint
   let body = RequestBodyLBS $ fromMaybe LBS.empty content
   let headers = [("Content-type", "application/json") | isJust content]
   let apiQuery = [("api_key", apiKey keys)

--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Datadog.Internal
-( datadogHttp
+( prependMaybe
+, prependBool
+, datadogHttp
 , decodeDatadog
 ) where
 
@@ -20,6 +22,15 @@ import Data.Text.Lazy.Encoding (decodeUtf8)
 import Network.HTTP.Client
 
 import Network.Datadog
+
+
+prependMaybe :: (a -> b) -> Maybe a -> [b] -> [b]
+prependMaybe _ Nothing = id
+prependMaybe f (Just a) = (f a :)
+
+
+prependBool :: Bool -> b -> [b] -> [b]
+prependBool p a = if p then (a :) else id
 
 
 datadogHttp :: Environment-> String -> [(String, String)] -> BS.ByteString -> Maybe LBS.ByteString -> IO LBS.ByteString

--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -1,19 +1,45 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Datadog.Internal
-( decodeDatadog
+( datadogHttp
+, decodeDatadog
 ) where
 
 
 import Control.Exception
 
 import Data.Aeson
-import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString as BS (ByteString)
+import qualified Data.ByteString.Lazy as LBS (ByteString, empty)
+import Data.Maybe
+import Data.Text (pack)
 import Data.Text.Lazy (unpack)
+import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 
+import Network.HTTP.Conduit
 
-decodeDatadog :: FromJSON a => String -> ByteString -> IO a
+import Network.Datadog
+
+
+datadogHttp :: Environment-> String -> [(String, String)] -> BS.ByteString -> Maybe LBS.ByteString -> IO LBS.ByteString
+datadogHttp (Environment keys manager) endpoint query httpMethod content = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/" ++ endpoint
+  let body = RequestBodyLBS $ fromMaybe LBS.empty content
+  let headers = [("Content-type", "application/json") | isJust content]
+  let apiQuery = [("api_key", apiKey keys)
+                 ,("application_key", appKey keys)]
+  let fullQuery = map (\(a,b) -> (encodeUtf8 (pack a), Just (encodeUtf8 (pack b)))) $
+                  apiQuery ++ query
+  let request = setQueryString fullQuery $
+                initReq { method = httpMethod
+                        , requestBody = body
+                        , requestHeaders = headers
+                        }
+  responseBody <$> httpLbs request manager
+
+
+decodeDatadog :: FromJSON a => String -> LBS.ByteString -> IO a
 decodeDatadog funcname body = either (throwIO . AssertionFailed . failstring) return $
                               eitherDecode body
   where failstring e = "Datadog Library decoding failure in \"" ++ funcname ++

--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -17,7 +17,7 @@ import Data.Text.Lazy (unpack)
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 
-import Network.HTTP.Conduit
+import Network.HTTP.Client
 
 import Network.Datadog
 

--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -20,6 +20,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Lazy.Encoding (decodeUtf8)
 
 import Network.HTTP.Client
+import Network.HTTP.Types
 
 import Network.Datadog
 
@@ -33,7 +34,7 @@ prependBool :: Bool -> b -> [b] -> [b]
 prependBool p a = if p then (a :) else id
 
 
-datadogHttp :: Environment-> String -> [(String, String)] -> BS.ByteString -> Maybe LBS.ByteString -> IO LBS.ByteString
+datadogHttp :: Environment-> String -> [(String, String)] -> StdMethod -> Maybe LBS.ByteString -> IO LBS.ByteString
 datadogHttp (Environment keys baseUrl manager) endpoint query httpMethod content = do
   initReq <- parseUrl $ baseUrl ++ endpoint
   let body = RequestBodyLBS $ fromMaybe LBS.empty content
@@ -43,7 +44,7 @@ datadogHttp (Environment keys baseUrl manager) endpoint query httpMethod content
   let fullQuery = map (\(a,b) -> (encodeUtf8 (pack a), Just (encodeUtf8 (pack b)))) $
                   apiQuery ++ query
   let request = setQueryString fullQuery $
-                initReq { method = httpMethod
+                initReq { method = renderStdMethod httpMethod
                         , requestBody = body
                         , requestHeaders = headers
                         }

--- a/src/Network/Datadog/Monitor.hs
+++ b/src/Network/Datadog/Monitor.hs
@@ -91,6 +91,8 @@ instance ToJSON MonitorType where
 
 instance FromJSON MonitorType where
   parseJSON (Data.Aeson.String "metric alert") = return MetricAlert
+  -- TODO figure out what "query alert" actually is
+  parseJSON (Data.Aeson.String "query alert") = return MetricAlert
   parseJSON (Data.Aeson.String "service check") = return ServiceCheck
   parseJSON (Data.Aeson.String s) = fail $ "MonitorType: String \"" ++ unpack s ++ "\" is not a valid MonitorType"
   parseJSON a = modifyFailure ("MonitorType: " ++) $ typeMismatch "String" a

--- a/src/Network/Datadog/Monitor.hs
+++ b/src/Network/Datadog/Monitor.hs
@@ -65,6 +65,8 @@ import qualified Data.Text as T (Text, null, pack, unpack)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
+import Network.HTTP.Types
+
 import Network.Datadog
 import Network.Datadog.Internal
 
@@ -318,7 +320,7 @@ instance FromJSON Monitor where
 createMonitor :: Environment -> MonitorSpec -> IO Monitor
 createMonitor env monitorspec =
   let path = "monitor"
-  in datadogHttp env path [] "POST" (Just $ encode monitorspec) >>=
+  in datadogHttp env path [] POST (Just $ encode monitorspec) >>=
      decodeDatadog "createMonitor"
 
 
@@ -326,7 +328,7 @@ createMonitor env monitorspec =
 loadMonitor :: Environment -> MonitorId -> IO Monitor
 loadMonitor env monitorId =
   let path = "monitor/" ++ show monitorId
-  in datadogHttp env path [] "GET" Nothing >>=
+  in datadogHttp env path [] GET Nothing >>=
      decodeDatadog "loadMonitor"
 
 
@@ -342,7 +344,7 @@ loadMonitor env monitorId =
 updateMonitor :: Environment -> MonitorId -> MonitorSpec -> IO Monitor
 updateMonitor env monitorId mspec =
   let path = "monitor/" ++ show monitorId
-  in datadogHttp env path [] "PUT" (Just $ encode mspec) >>=
+  in datadogHttp env path [] PUT (Just $ encode mspec) >>=
      decodeDatadog "updateMonitor"
 
 
@@ -354,7 +356,7 @@ updateMonitor env monitorId mspec =
 deleteMonitor :: Environment -> MonitorId -> IO ()
 deleteMonitor env monitorId =
   let path = "monitor/" ++ show monitorId
-  in void $ datadogHttp env path [] "DELETE" Nothing
+  in void $ datadogHttp env path [] DELETE Nothing
 
 
 -- | Load monitors from Datadog.
@@ -371,7 +373,7 @@ loadMonitors :: Environment
 loadMonitors env tags =
   let path = "monitor"
       query = [("tags", intercalate "," (map show tags)) | not (null tags)]
-  in datadogHttp env path query "GET" Nothing >>=
+  in datadogHttp env path query GET Nothing >>=
      decodeDatadog "loadMonitors"
 
 
@@ -379,11 +381,11 @@ loadMonitors env tags =
 muteAllMonitors :: Environment -> IO ()
 muteAllMonitors env =
   let path = "monitor/mute_all"
-  in void $ datadogHttp env path [] "POST" Nothing
+  in void $ datadogHttp env path [] POST Nothing
 
 
 -- | Allow all monitors to notify.
 unmuteAllMonitors :: Environment -> IO ()
 unmuteAllMonitors env =
   let path = "monitor/unmute_all"
-  in void $ datadogHttp env path [] "POST" Nothing
+  in void $ datadogHttp env path [] POST Nothing

--- a/src/Network/Datadog/Monitor.hs
+++ b/src/Network/Datadog/Monitor.hs
@@ -364,12 +364,12 @@ deleteMonitor env monitorId =
 -- than one filter tag, only metrics which match all filter tags will be
 -- provided.
 loadMonitors :: Environment
-             -> [Text]
+             -> [Tag]
              -- ^ Tags on which to filter the results
              -> IO [Monitor]
 loadMonitors env tags =
   let path = "monitor"
-      query = [("tags", intercalate "," (map unpack tags)) | not (null tags)]
+      query = [("tags", intercalate "," (map show tags)) | not (null tags)]
   in datadogHttp env path query "GET" Nothing >>=
      decodeDatadog "loadMonitors"
 

--- a/src/Network/Datadog/Monitor.hs
+++ b/src/Network/Datadog/Monitor.hs
@@ -305,9 +305,8 @@ data Monitor = Monitor { mId :: MonitorId
                        } deriving (Eq)
 
 instance ToJSON Monitor where
-  toJSON monitor = Object $ Data.HashMap.union basemap newmap
+  toJSON monitor = Object $ Data.HashMap.insert "id" (toJSON (mId monitor)) basemap
     where (Object basemap) = toJSON (mSpec monitor)
-          (Object newmap) = object ["id" .= mId monitor]
 
 instance FromJSON Monitor where
   parseJSON (Object v) = modifyFailure ("Monitor: " ++ ) $

--- a/src/Network/Datadog/Monitor.hs
+++ b/src/Network/Datadog/Monitor.hs
@@ -258,10 +258,12 @@ data MonitorSpec = MonitorSpec { msType :: MonitorType
 
 instance ToJSON MonitorSpec where
   toJSON ms = Object $ Data.HashMap.insert "options" (toJSON (msOptions ms)) hmap
-    where (Object hmap) = object (["type" .= pack (show (msType ms))
-                                  ,"query" .= msQuery ms]
-                                  ++ maybe [] (\a -> ["name" .=  a]) (msName ms)
-                                  ++ maybe [] (\a -> ["message" .=  a]) (msMessage ms))
+    where (Object hmap) = object $
+                          prependMaybe ("name" .=) (msName ms) $
+                          prependMaybe ("message" .=) (msMessage ms)
+                          ["type" .= pack (show (msType ms))
+                          ,"query" .= msQuery ms
+                          ]
 
 instance FromJSON MonitorSpec where
   parseJSON (Object v) = modifyFailure ("MonitorSpec: " ++) $

--- a/src/Network/Datadog/Monitor.hs
+++ b/src/Network/Datadog/Monitor.hs
@@ -1,0 +1,400 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Monitoring all of your infrastructure in one place wouldn’t be complete without
+the ability to know when critical changes are occurring. Datadog gives you the
+ability to create monitors that will actively check metrics, integration
+availability, network endpoints and more. Once a monitor is created, you will
+be notified when its conditions are met.
+
+A simple way to get started with monitors:
+
+> main = do
+>   env <- createEnvironment =<< loadKeysFromEnv
+>   -- Check if the average bytes received in the last five minutes is >100 on host0
+>   let query = "avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100"
+>   let mspec = minimalMonitorSpec MetricAlert query
+>   monitor <- createMonitor env mspec
+>   print $ mId monitor
+-}
+module Network.Datadog.Monitor
+( MonitorSpec(..)
+, MonitorType(..)
+, MonitorOptions
+, getSilencedMonitorScopes
+, silenceMonitorScope
+, unsilenceMonitorScope
+, unsilenceAllMonitorScope
+, doesNotifyOnNoMonitorData
+, notifyOnNoMonitorData
+, noNotifyOnNoMonitorData
+, getMonitorTimeout
+, setMonitorTimeout
+, clearMonitorTimeout
+, doesRenotifyMonitor
+, renotifyMonitor
+, noRenotifyMonitor
+, doesNotifyOnAudit
+, notifyOnAudit
+, noNotifyOnAudit
+, Monitor
+, mId
+, mSpec
+, MonitorId
+, minimalMonitorSpec
+, createMonitor
+, updateMonitor
+, deleteMonitor
+, loadMonitor
+, loadMonitors
+, muteAllMonitors
+, unmuteAllMonitors
+) where
+
+
+import Control.Arrow
+import Control.Exception
+import Control.Monad (mzero, void)
+
+import Data.Aeson
+import qualified Data.HashMap.Strict as Data.HashMap
+import Data.List (intercalate)
+import Data.Maybe
+import Data.Text (Text, pack, unpack)
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+
+import Network.HTTP.Conduit
+
+import Network.Datadog
+
+
+-- | Each monitor is of a specific type, which determines what sort of check
+-- the monitor performs.
+data MonitorType = MetricAlert
+                   -- ^ Watches a (combination of) metric(s), alerting when it
+                   -- crosses some threshold.
+                 | ServiceCheck
+                   -- ^ Watches a service and alerts when the service enters a
+                   -- failing state.
+                 deriving (Eq)
+
+instance Show MonitorType where
+  show MetricAlert = "metric alert"
+  show ServiceCheck = "service check"
+
+instance ToJSON MonitorType where
+  toJSON MetricAlert = Data.Aeson.String "metric alert"
+  toJSON ServiceCheck = Data.Aeson.String "service check"
+
+instance FromJSON MonitorType where
+  parseJSON (Data.Aeson.String "metric alert") = return MetricAlert
+  parseJSON (Data.Aeson.String "service check") = return ServiceCheck
+  parseJSON _ = mzero
+
+
+-- | Advanced configuration parameters for a monitor.
+data MonitorOptions = MonitorOptions { moSilenced :: Data.HashMap.HashMap Text (Maybe Integer)
+                                     , moNotifyNoData :: Bool
+                                     , moNoDataTimeframe :: Maybe Integer
+                                     , moTimeoutH :: Maybe Integer
+                                     , moRenotifyInterval :: Maybe Integer
+                                     , moEscalationMessage :: Text
+                                     , moNotifyAudit :: Bool
+                                     } deriving (Eq)
+
+instance ToJSON MonitorOptions where
+  toJSON options = Object $ Data.HashMap.fromList [("notify_no_data", Bool (moNotifyNoData options))
+                                                  ,("no_data_timeframe", maybe Null (Number . fromIntegral) (moNoDataTimeframe options))
+                                                  ,("timeout_h", maybe Null (Number . fromIntegral) (moTimeoutH options))
+                                                  ,("renotify_interval", maybe Null (Number . fromIntegral) (moRenotifyInterval options))
+                                                  ,("escalation_message", Data.Aeson.String (moEscalationMessage options))
+                                                  ,("notify_audit", Bool (moNotifyAudit options))]
+
+instance FromJSON MonitorOptions where
+  parseJSON (Object v) = MonitorOptions <$>
+                         v .:? "silenced" .!= Data.HashMap.empty <*>
+                         v .:? "notify_no_data" .!= False <*>
+                         v .:? "no_data_timeframe" .!= Nothing <*>
+                         v .:? "timeout_h" .!= Nothing <*>
+                         v .:? "renotify_interval" .!= Nothing <*>
+                         v .:? "escalation_message" .!= "" <*>
+                         v .:? "notify_audit" .!= False
+  parseJSON _ = mzero
+
+-- | Creates the most basic specification required by a monitor, containing the
+-- type of monitor and the query string used to detect the monitor's state.
+--
+-- Generates a set of "default" Monitor options, which specify as little
+-- optional configuration as possible.  This includes:
+--
+--   * No silencing of any part of the monitor
+--   * No notification when data related to the monitor is missing
+--   * No alert timeout after the monitor is triggeredn
+--   * No renotification when the monitor is triggered
+--   * No notification when the monitor is modified
+--
+-- In production situations, it is /not safe/ to rely on this documented
+-- default behaviour for critical setitngs; use the helper functions to
+-- introspect the MonitorOptions instance provided by this function. This also
+-- protects against future modifications to this API.
+defaultMonitorOptions :: MonitorOptions
+defaultMonitorOptions = MonitorOptions { moSilenced = Data.HashMap.empty
+                                       , moNotifyNoData = False
+                                       , moNoDataTimeframe = Nothing
+                                       , moTimeoutH = Nothing
+                                       , moRenotifyInterval = Nothing
+                                       , moEscalationMessage = ""
+                                       , moNotifyAudit = False
+                                       }
+
+-- | Provide a list of the silenced scopes for this monitor and the time at
+-- which the silencer will expire (may be indefinite). The monitor @ "*" @
+-- refers to the monitor at large (un-scoped).
+getSilencedMonitorScopes :: MonitorOptions -> [(Text, Maybe UTCTime)]
+getSilencedMonitorScopes options = map (second (fmap (posixSecondsToUTCTime . fromIntegral))) $ Data.HashMap.toList $ moSilenced options
+
+-- | Silence a given scope until some time (or indefinitely), replacing the
+-- current silencer on the given scope if one already exists.
+silenceMonitorScope :: Text -> Maybe UTCTime -> MonitorOptions -> MonitorOptions
+silenceMonitorScope scope mtime old = old { moSilenced = silenced }
+  where silenced = Data.HashMap.insert scope (fmap (floor . utcTimeToPOSIXSeconds) mtime) $ moSilenced old
+
+-- | Remove the silencer from a given scope, if the scope is currently
+-- silenced.
+unsilenceMonitorScope :: Text -> MonitorOptions -> MonitorOptions
+unsilenceMonitorScope scope old = old { moSilenced = silenced }
+  where silenced = Data.HashMap.delete scope $ moSilenced old
+
+-- | Unsilence every scope in the monitor, including the global scope.
+unsilenceAllMonitorScope :: MonitorOptions -> MonitorOptions
+unsilenceAllMonitorScope old = old { moSilenced = Data.HashMap.empty }
+
+-- | Determine how long without data a monitor will go before notifying to
+-- such, providing Nothing if the monitor will never notify on lack of data.
+doesNotifyOnNoMonitorData :: MonitorOptions -> Maybe NominalDiffTime
+doesNotifyOnNoMonitorData options = if moNotifyNoData options
+                                    then Just (maybe (throw (AssertionFailed "Datadog Library internal error")) (fromIntegral . (*60)) $ moNoDataTimeframe options)
+                                    else Nothing
+
+-- | Have the monitor notify when it does not receive data for some given
+-- amount of time (rounded down to the nearest minute).
+notifyOnNoMonitorData :: NominalDiffTime -> MonitorOptions -> MonitorOptions
+notifyOnNoMonitorData difftime old = old { moNotifyNoData = True, moNoDataTimeframe = Just stamp }
+  where stamp = floor (difftime / 60)
+
+-- | Prevent the monitor from notifying when it is missing data.
+noNotifyOnNoMonitorData :: MonitorOptions -> MonitorOptions
+noNotifyOnNoMonitorData old = old { moNotifyNoData = False, moNoDataTimeframe = Nothing }
+
+-- | Determine after how long the monitor will stop alerting after it is
+-- triggered, providing Nothing if the monitor will never stop alerting.
+getMonitorTimeout :: MonitorOptions -> Maybe NominalDiffTime
+getMonitorTimeout options = (fromIntegral . (*3600)) <$> moTimeoutH options
+
+-- | Have the monitor stop alerting some time after it is triggered (rounded up
+-- to the nearest hour).
+setMonitorTimeout :: NominalDiffTime -> MonitorOptions -> MonitorOptions
+setMonitorTimeout difftime old = old { moTimeoutH = Just stamp }
+  where stamp = ceiling (difftime / 3600)
+
+-- | Prevent the monitor from timing out after it is triggered.
+clearMonitorTimeout :: MonitorOptions -> MonitorOptions
+clearMonitorTimeout old = old { moTimeoutH = Nothing }
+
+-- | Determine after how long after being triggered the monitor will re-notify,
+-- and what message it will include in the re-notification (if any), providing
+-- Nothing if the monitor will never re-notify.
+doesRenotifyMonitor :: MonitorOptions -> Maybe (NominalDiffTime,Maybe Text)
+doesRenotifyMonitor options = (\i -> (fromIntegral (i * 60), result)) <$> moRenotifyInterval options
+  where message = moEscalationMessage options
+        result = if message == "" then Nothing else Just message
+
+-- | Have the monitor re-notify some amount of time after the most recent
+-- notification (rounded down to the nearest minute) and optionally what text
+-- it will include in the re-notification.
+renotifyMonitor :: NominalDiffTime -> Maybe Text -> MonitorOptions -> MonitorOptions
+renotifyMonitor difftime mmessage old = old { moRenotifyInterval = Just stamp, moEscalationMessage = message }
+  where stamp = floor (difftime / 60)
+        message = fromMaybe "" mmessage
+
+-- | Prevent the monitor from re-notifying after it triggers an un-resolved
+-- notification.
+noRenotifyMonitor :: MonitorOptions -> MonitorOptions
+noRenotifyMonitor old = old { moRenotifyInterval = Nothing, moEscalationMessage = "" }
+
+-- | Determine if the monitor triggers a notification when it is modified.
+doesNotifyOnAudit :: MonitorOptions -> Bool
+doesNotifyOnAudit = moNotifyAudit
+
+-- | Have the monitor trigger a notification when it is modified.
+notifyOnAudit :: MonitorOptions -> MonitorOptions
+notifyOnAudit old = old { moNotifyAudit = True }
+
+-- | Prevent the monitor from triggering a notification when it is modified.
+noNotifyOnAudit :: MonitorOptions -> MonitorOptions
+noNotifyOnAudit old = old { moNotifyAudit = False }
+
+
+-- | A representation of a monitor's configuration, from which a monitor could
+-- be rebuilt.
+data MonitorSpec = MonitorSpec { msType :: MonitorType
+                               , msQuery :: Text
+                                 -- ^ The query string the monitor uses to
+                                 -- determine its state.
+                               , msName :: Maybe Text
+                                 -- ^ The human-readable name of the monitor.
+                               , msMessage :: Maybe Text
+                                 -- ^ The message sent with the notification
+                                 -- when the monitor is triggered.
+                               , msOptions :: MonitorOptions
+                                 -- ^ Optional configuration parameters
+                                 -- specifying advanced monitor beahviour.
+                               } deriving (Eq)
+
+instance ToJSON MonitorSpec where
+  toJSON ms = Object $ Data.HashMap.insert "options" (toJSON (msOptions ms)) hmap
+    where (Object hmap) = object (["type" .= pack (show (msType ms))
+                                  ,"query" .= msQuery ms]
+                                  ++ maybe [] (\a -> ["name" .=  a]) (msName ms)
+                                  ++ maybe [] (\a -> ["message" .=  a]) (msMessage ms))
+
+instance FromJSON MonitorSpec where
+  parseJSON (Object v) = MonitorSpec <$>
+                         v .: "type" <*>
+                         v .: "query" <*>
+                         v .:? "name" .!= Nothing <*>
+                         v .:? "message" .!= Nothing <*>
+                         v .:? "options" .!= defaultMonitorOptions
+  parseJSON _ = mzero
+
+
+-- | Creates the most basic specification required by a monitor, containing the
+-- type of monitor and the query string used to detect the monitor's state.
+--
+-- This uses 'defaultMonitorOptions' to set the options (see that function for
+-- disclaimer(s)).
+minimalMonitorSpec :: MonitorType -> Text -> MonitorSpec
+minimalMonitorSpec cmtype cmquery = MonitorSpec { msType = cmtype
+                                                , msQuery = cmquery
+                                                , msName = Nothing
+                                                , msMessage = Nothing
+                                                , msOptions = defaultMonitorOptions
+                                                }
+
+
+-- | Datadog's internal reference to a specific monitor.
+type MonitorId = Int
+
+-- | A Datadog monitor. These monitors actively check multiple different types
+-- of data within Datadog against user-provided conditions, triggering
+-- notifications when condition(s) are met.
+data Monitor = Monitor { mId :: MonitorId
+                         -- ^ Datadog's internal reference to this specific
+                         -- monitor.
+                       , mSpec :: MonitorSpec
+                         -- ^ The specification from which this monitor can be
+                         -- re-created.
+                       } deriving (Eq)
+
+instance ToJSON Monitor where
+  toJSON monitor = Object $ Data.HashMap.union basemap newmap
+    where (Object basemap) = toJSON (mSpec monitor)
+          (Object newmap) = object ["id" .= mId monitor]
+
+instance FromJSON Monitor where
+  parseJSON (Object v) = Monitor <$> v .: "id" <*> parseJSON (Object v)
+  parseJSON _ = mzero
+
+
+-- | Create a new monitor in Datadog matching a specification.
+createMonitor :: Environment -> MonitorSpec -> IO Monitor
+createMonitor (Environment keys manager) monitorspec = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/monitor?api_key=" ++ apiKey keys
+             ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "POST"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode monitorspec)
+                        }
+  resp <- httpLbs request manager
+  maybe (throwIO (AssertionFailed "Datadog Library could not decode a Monitor")) return $ decode $ responseBody resp
+
+
+-- | Load a monitor from Datadog by its ID.
+loadMonitor :: Environment -> MonitorId -> IO Monitor
+loadMonitor (Environment keys manager) monitorId = do
+  request <- parseUrl $ "https://app.datadoghq.com/api/v1/monitor/" ++ show monitorId
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  resp <- httpLbs request manager
+  maybe (throwIO (AssertionFailed "Datadog Library could not decode an Event")) return $ decode $ responseBody resp
+
+
+-- | Sync a monitor with Datadog.
+--
+-- This must be called on any active monitors to apply the changes with Datadog
+-- itself; merely modifying a monitor locally is not enough to store the
+-- changes.
+--
+-- /Beware/: If a monitor has changed on the Datadog remote endpoint between
+-- the time it was copied locally and when this function is called, those
+-- changes already made remotely will be overwritten by this change.
+updateMonitor :: Environment -> MonitorId -> MonitorSpec -> IO Monitor
+updateMonitor (Environment keys manager) mid mspec = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/monitor/" ++ show mid
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "PUT"
+                        , requestHeaders = [("Content-type","application/json")]
+                        , requestBody = RequestBodyLBS (encode mspec)
+                        }
+  resp <- httpLbs request manager
+  maybe (throwIO (AssertionFailed "Datadog Library could not decode an Event")) return $ decode $ responseBody resp
+
+
+-- | Delete a monitor from Datadog.
+--
+-- Note that once a monitor is deleted, it cannot be used locally anymore,
+-- however you can always create a new monitor using the deleted monitor's
+-- specification.
+deleteMonitor :: Environment -> MonitorId -> IO ()
+deleteMonitor (Environment keys manager) monitorId = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/monitor/" ++ show monitorId
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "DELETE" }
+  void $ httpLbs request manager
+
+
+-- | Load monitors from Datadog.
+--
+-- This function takes a filter list argument, which should contain any tags
+-- the user wishes to filter on.  If the filter list is left empty, no filters
+-- will be applied.  The list of tags is ANDed together; if you specify more
+-- than one filter tag, only metrics which match all filter tags will be
+-- provided.
+loadMonitors :: Environment
+             -> [Text]
+             -- ^ Tags on which to filter the results
+             -> IO [Monitor]
+loadMonitors (Environment keys manager) tags = do
+  request <- parseUrl $ "https://app.datadoghq.com/api/v1/monitor?api_key=" ++ apiKey keys
+             ++ "&application_key=" ++ appKey keys
+             ++ if null tags then "" else "&tags=" ++ intercalate "," (map unpack tags)
+  resp <- httpLbs request manager
+  maybe (throwIO (AssertionFailed "Datadog Library could not decode Monitors")) return $ decode (responseBody resp)
+
+
+-- | Prevent all monitors from notifying indefinitely.
+muteAllMonitors :: Environment -> IO ()
+muteAllMonitors (Environment keys manager) = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/monitor/mute_all"
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "POST" }
+  void $ httpLbs request manager
+
+
+-- | Allow all monitors to notify.
+unmuteAllMonitors :: Environment -> IO ()
+unmuteAllMonitors (Environment keys manager) = do
+  initReq <- parseUrl $ "https://app.datadoghq.com/api/v1/monitor/unmute_all"
+             ++ "?api_key=" ++ apiKey keys ++ "&application_key=" ++ appKey keys
+  let request = initReq { method = "POST" }
+  void $ httpLbs request manager

--- a/test/Test/Network/Datadog.hs
+++ b/test/Test/Network/Datadog.hs
@@ -1,0 +1,23 @@
+module Test.Network.Datadog (tests) where
+
+
+import Distribution.TestSuite
+
+import qualified Test.Network.Datadog.StatsD as StatsD (tests)
+import qualified Test.Network.Datadog.Check as Check (tests)
+import qualified Test.Network.Datadog.Downtime as Downtime (tests)
+import qualified Test.Network.Datadog.Event as Event (tests)
+import qualified Test.Network.Datadog.Monitor as Monitor (tests)
+import qualified Test.Network.Datadog.Host as Host (tests)
+
+
+tests :: IO [Test]
+tests = map (\(s,t) -> Group s False t)
+        <$> mapM (\(s,tm) -> fmap (\t -> (s,t)) tm)
+        [("StatsD", StatsD.tests)]
+        -- ,("Check", Check.tests)
+        -- ,("Downtime", Downtime.tests)
+        -- ,("Event", Event.tests)
+        -- ,("Host", Host.tests)
+        -- ,("Monitor", Monitor.tests)
+        -- ]

--- a/test/Test/Network/Datadog.hs
+++ b/test/Test/Network/Datadog.hs
@@ -14,10 +14,10 @@ import qualified Test.Network.Datadog.Host as Host (tests)
 tests :: IO [Test]
 tests = map (\(s,t) -> Group s False t)
         <$> mapM (\(s,tm) -> fmap (\t -> (s,t)) tm)
-        [("StatsD", StatsD.tests)]
-        -- ,("Check", Check.tests)
-        -- ,("Downtime", Downtime.tests)
-        -- ,("Event", Event.tests)
-        -- ,("Host", Host.tests)
-        -- ,("Monitor", Monitor.tests)
-        -- ]
+        [("StatsD", StatsD.tests)
+        ,("Check", Check.tests)
+        ,("Downtime", Downtime.tests)
+        ,("Event", Event.tests)
+        ,("Host", Host.tests)
+        ,("Monitor", Monitor.tests)
+        ]

--- a/test/Test/Network/Datadog/Check.hs
+++ b/test/Test/Network/Datadog/Check.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Network.Datadog.Check (tests) where
+
+
+import Control.Concurrent (threadDelay)
+import Control.Exception
+
+import Distribution.TestSuite
+
+import Network.Datadog
+import Network.Datadog.Check
+
+
+tests :: IO [Test]
+tests = return [Test TestInstance { run = testCheckRecord
+                                  , name = "Test recording of a status check"
+                                  , tags = ["Check"]
+                                  , options = []
+                                  , setOption = \_ _ -> Left ""
+                                  }
+               ]
+
+
+environment :: IO Environment
+environment = createEnvironment =<< loadKeysFromEnv
+
+
+testCheckRecord :: IO Progress
+testCheckRecord = do
+  env <- environment
+  let check = CheckResult { crCheck = "Datadog Test Check"
+                          , crHostName = "development"
+                          , crStatus = CheckOk
+                          , crTimestamp = Nothing
+                          , crMessage = Nothing
+                          , crTags = []
+                          }
+  let computation = const (Finished Pass) <$> const (recordCheck env check) <$> threadDelay 500000
+  catch computation (\e -> return $ Finished $ Fail $ show (e :: SomeException))

--- a/test/Test/Network/Datadog/Downtime.hs
+++ b/test/Test/Network/Datadog/Downtime.hs
@@ -33,7 +33,7 @@ testDowntimeCycle = do
   env <- environment
   time <- getCurrentTime
   let downtimeDetails = minimalDowntimeSpec
-                        "haskell-datadog-test-scope"
+                        (read "haskell-datadog-test-scope")
   let downtimeUpdatedDetails = downtimeDetails { dsEnd = Just (addUTCTime 300 time) }
   let computation = do
         threadDelay 500000

--- a/test/Test/Network/Datadog/Downtime.hs
+++ b/test/Test/Network/Datadog/Downtime.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Network.Datadog.Downtime (tests) where
+
+
+import Control.Concurrent (threadDelay)
+import Control.Exception
+
+import Distribution.TestSuite
+
+import Data.Time.Clock
+
+import Network.Datadog
+import Network.Datadog.Downtime
+
+
+tests :: IO [Test]
+tests = return [Test TestInstance { run = testDowntimeCycle
+                                  , name = "Test downtime CRUD"
+                                  , tags = ["Downtime"]
+                                  , options = []
+                                  , setOption = \_ _ -> Left ""
+                                  }
+               ]
+
+
+environment :: IO Environment
+environment = createEnvironment =<< loadKeysFromEnv
+
+
+testDowntimeCycle :: IO Progress
+testDowntimeCycle = do
+  env <- environment
+  time <- getCurrentTime
+  let downtimeDetails = minimalDowntimeSpec
+                        "haskell-datadog-test-scope"
+  let downtimeUpdatedDetails = downtimeDetails { dsEnd = Just (addUTCTime 300 time) }
+  let computation = do
+        threadDelay 500000
+        downtime1 <- scheduleDowntime env downtimeDetails
+        threadDelay 500000
+        downtime2 <- updateDowntime env (dId downtime1) downtimeUpdatedDetails
+        threadDelay 500000
+        downtime3 <- loadDowntime env (dId downtime1)
+        threadDelay 500000
+        downtimes <- loadDowntimes env False
+        threadDelay 500000
+        cancelDowntime env (dId downtime1)
+        return (if downtime2 /= downtime3
+                then Finished (Fail "Updated and fetched downtimes are not identical")
+                else if downtime2 `notElem` downtimes
+                     then Finished (Fail (if downtime1 `elem` downtimes
+                                          then "Created downtime not updated (in group load)"
+                                          else "Updated downtime not fetched from group load"))
+                     else Finished Pass
+               )
+  catch computation (\e -> return $ Finished $ Fail $ show (e :: SomeException))

--- a/test/Test/Network/Datadog/Event.hs
+++ b/test/Test/Network/Datadog/Event.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Network.Datadog.Event (tests) where
+
+
+import Control.Concurrent (threadDelay)
+import Control.Exception
+
+import Distribution.TestSuite
+
+import Data.Time.Clock
+
+import Network.Datadog
+import Network.Datadog.Event
+
+
+tests :: IO [Test]
+tests = return [Test TestInstance { run = testEventCycle
+                                  , name = "Test event creation and loading methods"
+                                  , tags = ["Event"]
+                                  , options = []
+                                  , setOption = \_ _ -> Left ""
+                                  }
+               ]
+
+
+environment :: IO Environment
+environment = createEnvironment =<< loadKeysFromEnv
+
+
+testEventCycle :: IO Progress
+testEventCycle = do
+  env <- environment
+  time <- getCurrentTime
+  let eventDetails = minimalEventSpec
+                     "Datadog Test Event"
+                     "This is a test for the Haskell Datadog API."
+                     time
+                     NormalPriority
+  let computation = do
+        threadDelay 500000
+        event1 <- createEvent env eventDetails
+        threadDelay 10000000
+        event2 <- loadEvent env (eId event1)
+        threadDelay 500000
+        events <- loadEvents env (addUTCTime (-60) time, addUTCTime 60 time) Nothing []
+        return (if event1 /= event2
+                then Finished (Fail "Created and fetched events are not identical")
+                else if event1 `notElem` events
+                     then Finished (Fail "Created event not fetched from group load")
+                     else Finished Pass
+               )
+  catch computation (\e -> return $ Finished $ Fail $ show (e :: SomeException))

--- a/test/Test/Network/Datadog/Host.hs
+++ b/test/Test/Network/Datadog/Host.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Network.Datadog.Host (tests) where
+
+
+import Control.Concurrent (threadDelay)
+import Control.Exception
+
+import Distribution.TestSuite
+
+import Data.Time.Clock
+
+import Network.Datadog
+import Network.Datadog.Host
+
+
+tests :: IO [Test]
+tests = return [Test TestInstance { run = testHostMutes
+                                  , name = "Test host muting and unmuting"
+                                  , tags = ["Host"]
+                                  , options = []
+                                  , setOption = \_ _ -> Left ""
+                                  }
+               ]
+
+
+environment :: IO Environment
+environment = createEnvironment =<< loadKeysFromEnv
+
+
+performMute :: Maybe UTCTime -> Bool -> IO ()
+performMute time override = do
+  env <- environment
+  threadDelay 1000000
+  muteHost env "haskell-datadog-test-host" time override
+
+
+performUnmute :: IO ()
+performUnmute = do
+  env <- environment
+  threadDelay 1000000
+  unmuteHost env "haskell-datadog-test-host"
+
+
+testHostMutes :: IO Progress
+testHostMutes = do
+  time <- getCurrentTime
+  let computation = do
+        -- Ensure overriding works
+        performMute Nothing True
+        performMute (Just (addUTCTime 30 time)) True
+        -- Unmute the host before we test no override option
+        performUnmute
+        performMute Nothing False
+        -- Unmute for "cleanup"
+        performUnmute
+        return $ Finished Pass
+  catch computation (\e -> return $ Finished $ Fail $ show (e :: SomeException))

--- a/test/Test/Network/Datadog/Monitor.hs
+++ b/test/Test/Network/Datadog/Monitor.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Network.Datadog.Monitor (tests) where
+
+
+import Control.Concurrent (threadDelay)
+import Control.Exception
+
+import Distribution.TestSuite
+
+import Network.Datadog
+import Network.Datadog.Monitor
+
+
+tests :: IO [Test]
+tests = return [Test TestInstance { run = testMonitorCycle
+                                  , name = "Test monitor CRUD"
+                                  , tags = ["Monitor"]
+                                  , options = []
+                                  , setOption = \_ _ -> Left ""
+                                  }
+               ]
+
+
+environment :: IO Environment
+environment = createEnvironment =<< loadKeysFromEnv
+
+
+testMonitorCycle :: IO Progress
+testMonitorCycle = do
+  env <- environment
+  let monitorDetails = minimalMonitorSpec
+                       MetricAlert
+                       "avg(last_5m):sum:system.net.bytes_rcvd{host:host0} > 100"
+  let monitorUpdatedDetails = monitorDetails { msName = Just "Haskell Datadog test monitor" }
+  let computation = do
+        threadDelay 500000
+        monitor1 <- createMonitor env monitorDetails
+        threadDelay 500000
+        monitor2 <- updateMonitor env (mId monitor1) monitorUpdatedDetails
+        threadDelay 500000
+        monitor3 <- loadMonitor env (mId monitor1)
+        threadDelay 500000
+        monitors <- loadMonitors env []
+        threadDelay 500000
+        deleteMonitor env (mId monitor1)
+        return (if monitor2 /= monitor3
+                then Finished (Fail "Updated and fetched monitors are not identical")
+                else if monitor2 `notElem` monitors
+                     then Finished (Fail (if monitor1 `elem` monitors
+                                          then "Created monitor not updated (in group load)"
+                                          else "Updated monitor not fetched from group load"))
+                     else Finished Pass
+               )
+  catch computation (\e -> return $ Finished $ Fail $ show (e :: SomeException))

--- a/test/Test/Network/Datadog/StatsD.hs
+++ b/test/Test/Network/Datadog/StatsD.hs
@@ -1,16 +1,22 @@
-module Main where
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Network.Datadog.StatsD (tests) where
 import           Control.Exception
 import           Data.Maybe
-import           Network.Datadog.StatsD
+import           Distribution.TestSuite
+import           Network.Datadog.StatsD hiding (name, tags)
 import           Network.Socket hiding (send, sendTo, recv, recvFrom)
 import           Network.Socket.ByteString hiding (send)
 import           System.Timeout
-import           Test.Tasty
-import           Test.Tasty.HUnit
 
-main = defaultMain $ testGroup "Tests"
-  [ testCase "send" testSend
-  ]
+tests :: IO [Test]
+tests = return [Test TestInstance { run = testSend
+                                  , name = "Test sending DogStatsD data to a local server"
+                                  , tags = ["StatsD"]
+                                  , options = []
+                                  , setOption = \_ _ -> Left ""
+                                  }
+               ]
 
 makeServer :: IO Socket
 makeServer = do
@@ -21,9 +27,11 @@ makeServer = do
   bindSocket sock (addrAddress serverAddr)
   return sock
 
+testSend :: IO Progress
 testSend = bracket makeServer sClose $ \conn -> do
   withDogStatsD defaultSettings $ \stats -> do
     send stats $ event "foo" "bar"
   val <- timeout 10000000 $ recvFrom conn 2048
-  assertBool "Received event" $ isJust val
-
+  return $ Finished $ if isJust val
+                      then Pass
+                      else Fail "Did not receive DogStatsD event"


### PR DESCRIPTION
Hi.

I don't know proper etiquette for these kinds of things, I'm sorry.  I have been working the past few weeks on a library for the [Datadog HTTP API](http://docs.datadoghq.com/api/), and lo and behold, your library has cropped up since I initially checked for the existence of one.  I know my implementation of the API isn't very monadic (or applicative, or anything really) in its current form, but I hope that the core functionality still proves to be useful and can be built upon to create something more elegant.

it also has tests for the network calls, you can run them after setting up the API/app environment variables as described in the `Network.Datadog` module.

Thank you for taking the time to look at this!
