### PR TITLE
Add EventAlert monitor type

### DIFF
--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -275,12 +275,14 @@ instance ToJSON Metric where
 instance ToJSON MonitorType where
   toJSON MetricAlert = Data.Aeson.String "metric alert"
   toJSON ServiceCheck = Data.Aeson.String "service check"
+  toJSON EventAlert = Data.Aeson.String "event alert"
 
 instance FromJSON MonitorType where
   parseJSON (Data.Aeson.String "metric alert") = return MetricAlert
   -- TODO figure out what "query alert" actually is
   parseJSON (Data.Aeson.String "query alert") = return MetricAlert
   parseJSON (Data.Aeson.String "service check") = return ServiceCheck
+  parseJSON (Data.Aeson.String "event alert") = return EventAlert
   parseJSON (Data.Aeson.String s) = fail $ "MonitorType: String " ++ show s ++ " is not a valid MonitorType"
   parseJSON a = modifyFailure ("MonitorType: " ++) $ typeMismatch "String" a
 

--- a/src/Network/Datadog/Types.hs
+++ b/src/Network/Datadog/Types.hs
@@ -231,11 +231,15 @@ data MonitorType = MetricAlert
                  | ServiceCheck
                    -- ^ Watches a service and alerts when the service enters a
                    -- failing state.
+                 | EventAlert
+                   -- ^ Checks the event stream for events meeting certain
+                   -- criteria.
                  deriving (Eq)
 
 instance Show MonitorType where
   show MetricAlert = "metric alert"
   show ServiceCheck = "service check"
+  show EventAlert = "event alert"
 
 -- | Advanced configuration parameters for a monitor.
 data MonitorOptions = MonitorOptions { monitorOptionsSilenced :: HashMap T.Text (Maybe Integer)


### PR DESCRIPTION
Datadog dropped this new monitor type in, which fortunately is compatible with the existing monitor structure.
