### PR TITLE
Add back base version constraint

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,7 @@ ghc-options:
 dependencies:
   - aeson
   - auto-update
-  - base
+  - base >= 4.7 && < 5
   - buffer-builder
   - bytestring
   - dlist


### PR DESCRIPTION
Hackage won't let me upload without specifying a version range for base