### PR TITLE
app.datadoghq.com -> api.datadoghq.com

### DIFF
--- a/src/Network/Datadog.hs
+++ b/src/Network/Datadog.hs
@@ -51,7 +51,7 @@ loadKeysFromEnv = do
 -- | Create a new environment using authentication keys, defaulting to the
 -- Datadog documented default API URL.
 createEnvironment :: Keys -> IO Environment
-createEnvironment keys = fmap (Environment keys "https://app.datadoghq.com/api/v1/") managerIO
+createEnvironment keys = fmap (Environment keys "https://api.datadoghq.com/api/v1/") managerIO
   where managerIO = newManager tlsManagerSettings
 
 withDatadog :: DatadogCredentials k => k -> (DatadogClient k -> IO a) -> IO a

--- a/src/Network/Datadog/Internal.hs
+++ b/src/Network/Datadog/Internal.hs
@@ -72,7 +72,7 @@ decodeDatadog funcname body = either (throwIO . AssertionFailed . failstring) re
                        "\": " ++ e ++ ": " ++ unpack (decodeUtf8 body)
 
 baseRequest :: Request
-baseRequest = fromJust $ parseUrlThrow "https://app.datadoghq.com"
+baseRequest = fromJust $ parseUrlThrow "https://api.datadoghq.com"
 
 class DatadogCredentials s where
   signRequest :: s -> Request -> Request


### PR DESCRIPTION
The Datadog HTTP API docs now reference `https://api.datadoghq.com/api/v1/`. The old URI seems to still work, but perhaps it'll be deprecated at some point.