### PR TITLE
Make Tag testable

### DIFF
--- a/src/Network/StatsD/Datadog.hs
+++ b/src/Network/StatsD/Datadog.hs
@@ -63,6 +63,7 @@ import Control.Reaper
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as L
 import Data.BufferBuilder.Utf8
+import Data.Function (on)
 import Data.List (intersperse)
 import qualified Data.Sequence as Seq
 import qualified Data.ByteString as B
@@ -71,7 +72,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
-import Data.Text.Encoding (encodeUtf8)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import Network.Socket hiding (send, sendTo, recv, recvFrom)
 import System.IO
   ( BufferMode(BlockBuffering)
@@ -102,6 +103,9 @@ escapeEventContents = T.replace "\n" "\\n"
 -- For example, if you wanted to measure the performance of two video rendering algorithms,
 -- you could tag the rendering time metric with the version of the algorithm you used.
 newtype Tag = Tag { fromTag :: Utf8Builder () }
+
+instance Show Tag where show = ("Tag " ++) . T.unpack . decodeUtf8 . runUtf8Builder . fromTag
+instance Eq Tag where (==) = (==) `on` show
 
 -- | Create a tag from a key-value pair. Useful for slicing and dicing events in Datadog.
 --

--- a/src/Network/StatsD/Datadog.hs
+++ b/src/Network/StatsD/Datadog.hs
@@ -27,7 +27,7 @@ module Network.StatsD.Datadog (
   ServiceCheckStatus(..),
   ToStatsD,
   -- * Optional fields
-  Tag,
+  Tag(fromTag),
   tag,
   ToMetricValue(..),
   value,


### PR DESCRIPTION
I have some code that uses `Tag` in it, but I am unable to test it as is, because I have no way to test the underlying equality of `Tag`s. Making my code polymorphic and mocking `Tag`s is not super feasible either. 

I have two solutions to this problem and I'm open to either or both. 
1. Add a `Show` instance (Bonus: also add an `Eq` instance)
2. Export `fromTag` (Bonus: also export the `Tag` constructor)

Thoughts? 