### PR TITLE
Bump to LTS 18 and adds support for Aeson 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 dist
 cabal-dev
-*.cabal
 *.o
 *.hi
 *.chi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ cache:
 env:
   - STACK_YAML="stack-lts11.yaml"
   - STACK_YAML="stack-lts14.yaml"
+  - STACK_YAML="stack-lts16.yaml"
+  - STACK_YAML="stack-lts18-aeson2.yaml"
   - STACK_YAML="stack.yaml"
   - ARGS="--resolver lts"
   - ARGS="--resolver nightly"

--- a/datadog.cabal
+++ b/datadog.cabal
@@ -1,0 +1,156 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           datadog
+version:        0.2.5.0
+synopsis:       Datadog client for Haskell. Supports both the HTTP API and StatsD.
+category:       Network
+homepage:       https://github.com/iand675/datadog
+author:         Ian Duncan
+maintainer:     Ian Duncan <ian@iankduncan.com>, Kostiantyn Rybnikov <k-bx@k-bx.com>
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+
+library
+  exposed-modules:
+      Network.Datadog
+      Network.Datadog.Check
+      Network.Datadog.Downtime
+      Network.Datadog.Event
+      Network.Datadog.Host
+      Network.Datadog.Internal
+      Network.Datadog.Lens
+      Network.Datadog.Metrics
+      Network.Datadog.Monitor
+      Network.Datadog.Types
+      Network.StatsD.Datadog
+  other-modules:
+      Paths_datadog
+  hs-source-dirs:
+      src
+  default-extensions:
+      ConstraintKinds
+      DataKinds
+      DeriveDataTypeable
+      DeriveGeneric
+      EmptyDataDecls
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NoMonomorphismRestriction
+      OverloadedStrings
+      PackageImports
+      PolyKinds
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      ViewPatterns
+  ghc-options: -Wall -fwarn-tabs -O2
+  build-depends:
+      aeson
+    , auto-update
+    , base >=4.7 && <5
+    , buffer-builder
+    , bytestring
+    , containers
+    , dlist
+    , http-client
+    , http-client-tls
+    , http-types
+    , lens
+    , lifted-base
+    , monad-control
+    , network
+    , old-locale
+    , text
+    , time
+    , transformers-base
+    , unliftio
+    , unordered-containers
+    , vector
+  default-language: Haskell2010
+
+test-suite datadog-api-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Test.Network.Datadog
+      Test.Network.Datadog.Check
+      Test.Network.Datadog.Downtime
+      Test.Network.Datadog.Event
+      Test.Network.Datadog.Host
+      Test.Network.Datadog.Monitor
+      Test.Network.Datadog.StatsD
+      Paths_datadog
+  hs-source-dirs:
+      test
+  default-extensions:
+      ConstraintKinds
+      DataKinds
+      DeriveDataTypeable
+      DeriveGeneric
+      EmptyDataDecls
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NoMonomorphismRestriction
+      OverloadedStrings
+      PackageImports
+      PolyKinds
+      QuasiQuotes
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      ViewPatterns
+  ghc-options: -Wall -fwarn-tabs -O2
+  build-depends:
+      Cabal
+    , aeson
+    , auto-update
+    , base
+    , buffer-builder
+    , bytestring
+    , containers
+    , datadog
+    , dlist
+    , exceptions
+    , hspec
+    , http-client
+    , http-client-tls
+    , http-types
+    , lens
+    , lifted-base
+    , monad-control
+    , network
+    , old-locale
+    , random
+    , text
+    , time
+    , transformers-base
+    , unliftio
+    , unordered-containers
+    , vector
+  default-language: Haskell2010

--- a/stack-aeson2.yaml
+++ b/stack-aeson2.yaml
@@ -1,0 +1,14 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+resolver: lts-18.21
+extra-deps:
+  - aeson-2.0.3.0
+  - OneTuple-0.3.1
+  - attoparsec-0.14.3
+  - hashable-1.3.5.0
+  - semialign-1.2.0.1
+  - text-short-0.1.5
+  - time-compat-1.9.6.1
+

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -2,5 +2,5 @@ flags: {}
 extra-package-dbs: []
 packages:
 - '.'
-resolver: lts-18.21
+resolver: lts-16.26
 extra-deps: []


### PR DESCRIPTION
The default configuration has been bumped to LTS 18. A secondary LTS 18
yaml file was also added, that adds support for Aeson 2.

ADditionally, based on new tooling recommendations, the cabal file is
now checked in, and included as part of the repo.

Fixes #40 